### PR TITLE
Spelling correction

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: gitstream/cache.json
-        key: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).headSha }}-gitsream-cache
+        key: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).headSha }}-gitstream-cache
 
     - name: Checkout head branch
       uses: actions/checkout@v3


### PR DESCRIPTION
Reading through the GitHub Action Cache in the project and seeing cache objects like `3fd7da58cc48eb087c7852c2d89d60f57bd6dc80-gitsream-cache`... Changing `gitsream` to `gitstream` is a small one but helps my OCD. 🙏 