### PR TITLE
fix: use repo as default url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
         cd gitstream
         cd repo
         git fetch --deepen=$all origin ${{ github.event.inputs.base_ref }}
-        git remote add upstream ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).headHttpUrl }}
+        git remote add upstream ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).headHttpUrl || fromJSON(fromJSON(github.event.inputs.client_payload)).repoUrl }}
         git fetch --deepen=$all upstream ${{ github.event.inputs.head_ref }}
         git checkout -b ${{ github.event.inputs.head_ref }} upstream/${{ github.event.inputs.head_ref }}
       shell: bash


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19mEssPrbWzpl9Px9lo565idJnQp6HW3Lo%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=aFHl8RC)