### PR TITLE
fix: move to upstream instead of create

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,8 @@ runs:
         cd repo
         git fetch --deepen=$all origin ${{ github.event.inputs.base_ref }}
         git remote add upstream ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).headHttpUrl || fromJSON(fromJSON(github.event.inputs.client_payload)).repoUrl }}
-        git checkout -b upstream/${{ github.event.inputs.head_ref }}
         git fetch --deepen=$all upstream ${{ github.event.inputs.head_ref }}
+        git checkout -b upstream/${{ github.event.inputs.head_ref }} upstream/${{ github.event.inputs.head_ref }}
       shell: bash
     - name: Create cm folder
       id: create-cm-folder


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18O8f8FDOEKqvu2zLMEq3IeT0ohn9kt3A%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=T1hH812)