### PR TITLE
Linbee 6728 add option to run GitHub action with cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,11 @@ inputs:
   debug_mode:
     description: "Run parser in debug mode"
     required: false
-    default: false
+    default: "false"
+  pull_docker_from_cache:
+    description: "If should store gitstream docker in GitHub cache"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -100,6 +104,17 @@ runs:
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
         path: "gitstream/cm/"
 
+    - name: Docker Layer Caching
+      if: ${{ inputs.pull_docker_from_cache == 'true' }}
+      uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
+      with:
+        concurrency: 12
+
+    - name: Pull gitstream Docker
+      shell: bash
+      run: docker pull gitstream/rules-engine:latest
+
     - name: Run The Action
       if: always()
       run: |
@@ -109,7 +124,6 @@ runs:
           value="${!var}"
           echo "$var=$value" >> "$env_file"
         done
-        docker pull gitstream/rules-engine:latest
         docker run --env-file $env_file \
           -v $(pwd)/gitstream:/code \
           -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,13 @@ runs:
   steps:
     - name: Check pull_docker_from_cache as boolean
       shell: bash
-      if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).pull_docker_from_cache == true }}
+      if: ${{ fromJSON(github.event.inputs).pull_docker_from_cache == true }}
       run: |
         echo "Check pull_docker_from_cache as boolean"
         
     - name: Check pull_docker_from_cache as string
       shell: bash
-      if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).pull_docker_from_cache == 'true' }}
+      if: ${{ fromJSON(github.event.inputs).pull_docker_from_cache == 'true' }}
       run: |
         echo "Check pull_docker_from_cache as string"
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Run parser in debug mode"
     required: false
     default: 'false'
+  pull_docker_from_cache:
+    description: "If should store gitstream docker in GitHub cache"
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -102,6 +106,7 @@ runs:
         path: "gitstream/cm/"
 
     - name: Docker Layer Caching
+      if: github.event.inputs.pull_docker_from_cache == 'true'
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -25,16 +25,11 @@ inputs:
   debug_mode:
     description: "Run parser in debug mode"
     required: false
-    default: "false"
-  pull_docker_from_cache:
-    description: "If should store gitstream docker in GitHub cache"
-    required: false
-    default: "false"
+    default: false
 runs:
   using: "composite"
   steps:
     - name: Create GitStream folder
-      id: create-gitstream-folder
       shell: bash
       run: |
         rm -rf gitstream
@@ -43,7 +38,7 @@ runs:
         mkdir repo
 
     - name: Checkout base branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.full_repository }}
         ref: ${{ github.event.inputs.base_ref }}
@@ -52,7 +47,7 @@ runs:
 
     - name: Escape single quotes
       id: safe-strings
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         BASE_REF_ARG: ${{ github.event.inputs.base_ref }}
         HEAD_REF_ARG: ${{ github.event.inputs.head_ref }}
@@ -79,6 +74,7 @@ runs:
             core.error(`Failed producing safe string: ${err}`);
             process.exit(1);
           }
+
     - name: Checkout Pull Request branches history
       run: |
         all=2147483647
@@ -91,33 +87,20 @@ runs:
       shell: bash
 
     - name: Create cm folder
-      id: create-cm-folder
       shell: bash
       run: |
         cd gitstream
         mkdir cm
 
     - name: Checkout cm repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).hasCmRepo == true }}
       with:
         repository: "${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}"
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
         path: "gitstream/cm/"
 
-    - name: Docker Layer Caching
-      if: ${{ inputs.pull_docker_from_cache == 'true' }}
-      uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-      with:
-        concurrency: 12
-
-    - name: Pull gitstream Docker
-      shell: bash
-      run: docker pull gitstream/rules-engine:latest
-
     - name: Run The Action
-      id: gitstream-action
       if: always()
       run: |
         env_file=env.user
@@ -127,5 +110,12 @@ runs:
           echo "$var=$value" >> "$env_file"
         done
         docker pull gitstream/rules-engine:latest
-        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
+        docker run --env-file $env_file \
+          -v $(pwd)/gitstream:/code \
+          -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \
+          -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' \
+          -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} \
+          -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} \
+          -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} \
+          -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine:latest
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,13 @@ runs:
   steps:
     - name: Check pull_docker_from_cache as boolean
       shell: bash
-      if: ${{ github.event.inputs.pull_docker_from_cache == true }}
+      if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).pull_docker_from_cache == true }}
       run: |
         echo "Check pull_docker_from_cache as boolean"
         
     - name: Check pull_docker_from_cache as string
       shell: bash
-      if: ${{ github.event.inputs.pull_docker_from_cache == 'true' }}
+      if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).pull_docker_from_cache == 'true' }}
       run: |
         echo "Check pull_docker_from_cache as string"
 

--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,6 @@ runs:
           value="${!var}"
           echo "$var=$value" >> "$env_file"
         done
-        docker pull gitstream/rules-engine:latest
         docker run --env-file $env_file \
           -v $(pwd)/gitstream:/code \
           -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check Docker Rate Limits
+      run: |
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer ${{ env.TOKEN }}" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
     - name: Create GitStream folder
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   pull_docker_from_cache:
     description: "If should store gitstream docker in GitHub cache"
     required: false
-    default: false
+    default: 'false'
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,37 @@
-name: "gitStream repo agent"
-description: "Public GitHub action for gitStream Continuous Merge"
+name: 'gitStream repo agent'
+description: 'Public GitHub action for gitStream Continuous Merge'
 inputs:
   full_repository:
-    description: "Path of full Repository"
+    description: 'Path of full Repository'
     required: true
   head_ref:
-    description: "Head Branch Ref to checkout to"
+    description: 'Head Branch Ref to checkout to'
     required: true
   base_ref:
-    description: "Base Branch Ref to checkout to"
+    description: 'Base Branch Ref to checkout to'
     required: true
   client_payload:
-    description: "The client payload"
+    description: 'The client payload'
     required: true
   installation_id:
-    description: "The github app installation id"
+    description: 'The github app installation id'
     required: false
   resolver_url:
-    description: "Resolver url to send results to"
+    description: 'Resolver url to send results to'
     required: true
   resolver_token:
-    description: "Optional token for resolver"
+    description: 'Optional token for resolver'
     required: false
   debug_mode:
-    description: "Run parser in debug mode"
+    description: 'Run parser in debug mode'
     required: false
     default: 'false'
   pull_docker_from_cache:
-    description: "If should store gitstream docker in GitHub cache"
+    description: 'If should store gitstream docker in GitHub cache'
     required: false
     default: 'true'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Create GitStream folder
       id: create-gitstream-folder
@@ -47,7 +47,7 @@ runs:
       with:
         repository: ${{ inputs.full_repository }}
         ref: ${{ github.event.inputs.base_ref }}
-        path: "gitstream/repo/"
+        path: 'gitstream/repo/'
         token: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).githubToken || github.token }}
 
     - name: Escape single quotes
@@ -102,14 +102,16 @@ runs:
       uses: actions/checkout@v4
       if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).hasCmRepo == true }}
       with:
-        repository: "${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}"
+        repository: '${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}'
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
-        path: "gitstream/cm/"
+        path: 'gitstream/cm/'
 
     - name: Docker Layer Caching
       if: ${{ inputs.pull_docker_from_cache == 'true' }}
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
+      with:
+        concurrency: 12
 
     - name: Pull gitstream Docker
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Check Docker Rate Limits
+      shell: bash
       run: |
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl --head -H "Authorization: Bearer ${{ env.TOKEN }}" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   pull_docker_from_cache:
     description: "If should store gitstream docker in GitHub cache"
     required: false
-    default: "true"
+    default: "false"
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -1,48 +1,48 @@
-name: 'gitStream repo agent'
-description: 'Public GitHub action for gitStream Continuous Merge'
+name: "gitStream repo agent"
+description: "Public GitHub action for gitStream Continuous Merge"
 inputs:
   full_repository:
-    description: 'Path of full Repository'
+    description: "Path of full Repository"
     required: true
   head_ref:
-    description: 'Head Branch Ref to checkout to'
+    description: "Head Branch Ref to checkout to"
     required: true
   base_ref:
-    description: 'Base Branch Ref to checkout to'
+    description: "Base Branch Ref to checkout to"
     required: true
   client_payload:
-    description: 'The client payload'
+    description: "The client payload"
     required: true
   installation_id:
-    description: 'The github app installation id'
+    description: "The github app installation id"
     required: false
   resolver_url:
-    description: 'Resolver url to send results to'
+    description: "Resolver url to send results to"
     required: true
   resolver_token:
-    description: 'Optional token for resolver'
+    description: "Optional token for resolver"
     required: false
   debug_mode:
-    description: 'Run parser in debug mode'
+    description: "Run parser in debug mode"
     required: false
     default: 'false'
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Create GitStream folder
+      id: create-gitstream-folder
       shell: bash
       run: |
         rm -rf gitstream
         mkdir gitstream
         cd gitstream
         mkdir repo
-
     - name: Checkout base branch
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.full_repository }}
         ref: ${{ github.event.inputs.base_ref }}
-        path: 'gitstream/repo/'
+        path: "gitstream/repo/"
         token: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).githubToken || github.token }}
 
     - name: Escape single quotes
@@ -94,12 +94,20 @@ runs:
         mkdir cm
 
     - name: Checkout cm repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).hasCmRepo == true }}
       with:
-        repository: '${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}'
+        repository: "${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}"
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
-        path: 'gitstream/cm/'
+        path: "gitstream/cm/"
+
+    - name: Docker Layer Caching
+      uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
+
+    - name: Pull gitstream Docker
+      shell: bash
+      run: docker pull gitstream/rules-engine:latest
 
     - name: Run The Action
       id: gitstream-action
@@ -111,6 +119,12 @@ runs:
           value="${!var}"
           echo "$var=$value" >> "$env_file"
         done
-        docker pull gitstream/rules-engine:mishaTest
-        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine:mishaTest
+        docker run --env-file $env_file -v $(pwd)/gitstream:/code \
+          -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \
+          -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' \
+          -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} \
+          -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} \
+          -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} \
+          -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} \
+          gitstream/rules-engine:latest
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
         mkdir repo
 
     - name: Checkout base branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: ${{ inputs.full_repository }}
         ref: ${{ github.event.inputs.base_ref }}

--- a/action.yml
+++ b/action.yml
@@ -33,23 +33,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Check pull_docker_from_cache as boolean
-      shell: bash
-      if: ${{ inputs.pull_docker_from_cache == true }}
-      run: |
-        echo "Check pull_docker_from_cache as boolean"
-        
-    - name: Check pull_docker_from_cache as string
-      shell: bash
-      if: ${{ inputs.pull_docker_from_cache == 'true' }}
-      run: |
-        echo "Check pull_docker_from_cache as string"
-
     - name: Create GitStream folder
       id: create-gitstream-folder
       shell: bash
       run: |
-        echo "misha1"
         rm -rf gitstream
         mkdir gitstream
         cd gitstream
@@ -120,7 +107,7 @@ runs:
         path: "gitstream/cm/"
 
     - name: Docker Layer Caching
-      if: ${{ github.event.inputs.pull_docker_from_cache == true }}
+      if: ${{ inputs.pull_docker_from_cache == 'true' }}
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,37 @@
-name: 'gitStream repo agent'
-description: 'Public GitHub action for gitStream Continuous Merge'
+name: "gitStream repo agent"
+description: "Public GitHub action for gitStream Continuous Merge"
 inputs:
   full_repository:
-    description: 'Path of full Repository'
+    description: "Path of full Repository"
     required: true
   head_ref:
-    description: 'Head Branch Ref to checkout to'
+    description: "Head Branch Ref to checkout to"
     required: true
   base_ref:
-    description: 'Base Branch Ref to checkout to'
+    description: "Base Branch Ref to checkout to"
     required: true
   client_payload:
-    description: 'The client payload'
+    description: "The client payload"
     required: true
   installation_id:
-    description: 'The github app installation id'
+    description: "The github app installation id"
     required: false
   resolver_url:
-    description: 'Resolver url to send results to'
+    description: "Resolver url to send results to"
     required: true
   resolver_token:
-    description: 'Optional token for resolver'
+    description: "Optional token for resolver"
     required: false
   debug_mode:
-    description: 'Run parser in debug mode'
+    description: "Run parser in debug mode"
     required: false
-    default: 'false'
+    default: "false"
   pull_docker_from_cache:
-    description: 'If should store gitstream docker in GitHub cache'
+    description: "If should store gitstream docker in GitHub cache"
     required: false
-    default: 'true'
+    default: "true"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Create GitStream folder
       id: create-gitstream-folder
@@ -47,7 +47,7 @@ runs:
       with:
         repository: ${{ inputs.full_repository }}
         ref: ${{ github.event.inputs.base_ref }}
-        path: 'gitstream/repo/'
+        path: "gitstream/repo/"
         token: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).githubToken || github.token }}
 
     - name: Escape single quotes
@@ -79,7 +79,6 @@ runs:
             core.error(`Failed producing safe string: ${err}`);
             process.exit(1);
           }
-
     - name: Checkout Pull Request branches history
       run: |
         all=2147483647
@@ -99,12 +98,12 @@ runs:
         mkdir cm
 
     - name: Checkout cm repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).hasCmRepo == true }}
       with:
-        repository: '${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}'
+        repository: "${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}"
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
-        path: 'gitstream/cm/'
+        path: "gitstream/cm/"
 
     - name: Docker Layer Caching
       if: ${{ inputs.pull_docker_from_cache == 'true' }}
@@ -127,12 +126,6 @@ runs:
           value="${!var}"
           echo "$var=$value" >> "$env_file"
         done
-        docker run --env-file $env_file -v $(pwd)/gitstream:/code \
-          -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \
-          -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' \
-          -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} \
-          -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} \
-          -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} \
-          -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} \
-          gitstream/rules-engine:latest
+        docker pull gitstream/rules-engine:latest
+        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ runs:
         mkdir gitstream
         cd gitstream
         mkdir repo
+
     - name: Checkout base branch
       uses: actions/checkout@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check pull_docker_from_cache as boolean
+      shell: bash
+      if: ${{ github.event.inputs.pull_docker_from_cache == true }}
+      run: |
+        echo "Check pull_docker_from_cache as boolean"
+        
+    - name: Check pull_docker_from_cache as string
+      shell: bash
+      if: ${{ github.event.inputs.pull_docker_from_cache == 'true' }}
+      run: |
+        echo "Check pull_docker_from_cache as string"
+
     - name: Create GitStream folder
       id: create-gitstream-folder
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   pull_docker_from_cache:
     description: "If should store gitstream docker in GitHub cache"
     required: false
-    default: 'false'
+    default: false
 runs:
   using: "composite"
   steps:
@@ -107,7 +107,7 @@ runs:
         path: "gitstream/cm/"
 
     - name: Docker Layer Caching
-      if: github.event.inputs.pull_docker_from_cache == true
+      if: ${{ github.event.inputs.pull_docker_from_cache == true }}
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -112,5 +112,5 @@ runs:
           echo "$var=$value" >> "$env_file"
         done
         docker pull gitstream/rules-engine:mishaTest
-        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
+        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine:mishaTest
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
       id: create-gitstream-folder
       shell: bash
       run: |
+        echo "misha1"
         rm -rf gitstream
         mkdir gitstream
         cd gitstream

--- a/action.yml
+++ b/action.yml
@@ -1,49 +1,50 @@
-name: "gitStream repo agent"
-description: "Public GitHub action for gitStream Continuous Merge"
+name: 'gitStream repo agent'
+description: 'Public GitHub action for gitStream Continuous Merge'
 inputs:
   full_repository:
-    description: "Path of full Repository"
+    description: 'Path of full Repository'
     required: true
   head_ref:
-    description: "Head Branch Ref to checkout to"
+    description: 'Head Branch Ref to checkout to'
     required: true
   base_ref:
-    description: "Base Branch Ref to checkout to"
+    description: 'Base Branch Ref to checkout to'
     required: true
   client_payload:
-    description: "The client payload"
+    description: 'The client payload'
     required: true
   installation_id:
-    description: "The github app installation id"
+    description: 'The github app installation id'
     required: false
   resolver_url:
-    description: "Resolver url to send results to"
+    description: 'Resolver url to send results to'
     required: true
   resolver_token:
-    description: "Optional token for resolver"
+    description: 'Optional token for resolver'
     required: false
   debug_mode:
-    description: "Run parser in debug mode"
+    description: 'Run parser in debug mode'
     required: false
-    default: false
+    default: 'false'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Create GitStream folder
-      id: create-gitstream-folder
       shell: bash
       run: |
         rm -rf gitstream
         mkdir gitstream
         cd gitstream
         mkdir repo
+
     - name: Checkout base branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.full_repository }}
         ref: ${{ github.event.inputs.base_ref }}
-        path: "gitstream/repo/"
+        path: 'gitstream/repo/'
         token: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).githubToken || github.token }}
+
     - name: Escape single quotes
       id: safe-strings
       uses: actions/github-script@v6
@@ -73,6 +74,7 @@ runs:
             core.error(`Failed producing safe string: ${err}`);
             process.exit(1);
           }
+
     - name: Checkout Pull Request branches history
       run: |
         all=2147483647
@@ -83,19 +85,22 @@ runs:
         git fetch --deepen=$all upstream $'${{ steps.safe-strings.outputs.head_ref }}'
         git checkout -b $'upstream/${{ steps.safe-strings.outputs.head_ref}}' $'upstream/${{ steps.safe-strings.outputs.head_ref}}'
       shell: bash
+
     - name: Create cm folder
       id: create-cm-folder
       shell: bash
       run: |
         cd gitstream
         mkdir cm
+
     - name: Checkout cm repo
       uses: actions/checkout@v3
       if: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).hasCmRepo == true }}
       with:
-        repository: "${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}"
+        repository: '${{ fromJSON(fromJSON(github.event.inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepo }}'
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
-        path: "gitstream/cm/"
+        path: 'gitstream/cm/'
+
     - name: Run The Action
       id: gitstream-action
       if: always()
@@ -106,6 +111,13 @@ runs:
           value="${!var}"
           echo "$var=$value" >> "$env_file"
         done
-        docker pull gitstream/rules-engine:latest
-        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
+        docker pull gitstream/rules-engine:mishaTest
+        docker run --env-file $env_file \ 
+        -v $(pwd)/gitstream:/code \
+        -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \
+        -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' \
+        -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} \
+        -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} \
+        -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} \
+        -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,13 @@ runs:
   steps:
     - name: Check pull_docker_from_cache as boolean
       shell: bash
-      if: ${{ fromJSON(github.event.inputs).pull_docker_from_cache == true }}
+      if: ${{ inputs.pull_docker_from_cache == true }}
       run: |
         echo "Check pull_docker_from_cache as boolean"
         
     - name: Check pull_docker_from_cache as string
       shell: bash
-      if: ${{ fromJSON(github.event.inputs).pull_docker_from_cache == 'true' }}
+      if: ${{ inputs.pull_docker_from_cache == 'true' }}
       run: |
         echo "Check pull_docker_from_cache as string"
 

--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
         path: "gitstream/cm/"
 
     - name: Docker Layer Caching
-      if: github.event.inputs.pull_docker_from_cache == 'true'
+      if: github.event.inputs.pull_docker_from_cache == true
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -112,12 +112,5 @@ runs:
           echo "$var=$value" >> "$env_file"
         done
         docker pull gitstream/rules-engine:mishaTest
-        docker run --env-file $env_file \ 
-        -v $(pwd)/gitstream:/code \
-        -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \
-        -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' \
-        -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} \
-        -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} \
-        -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} \
-        -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
+        docker run --env-file $env_file -v $(pwd)/gitstream:/code -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' -e BASE_REF=$'${{ steps.safe-strings.outputs.base_ref }}' -e CLIENT_PAYLOAD=${{ steps.safe-strings.outputs.client_payload }} -e RULES_RESOLVER_URL=${{ github.event.inputs.resolver_url }} -e RULES_RESOLVER_TOKEN=${{ github.event.inputs.resolver_token }} -e DEBUG_MODE=${{ github.event.inputs.debug_mode }} gitstream/rules-engine
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   pull_docker_from_cache:
     description: "If should store gitstream docker in GitHub cache"
     required: false
-    default: 'false'
+    default: 'true'
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Check Docker Rate Limits
-      shell: bash
-      run: |
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer ${{ env.TOKEN }}" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
     - name: Create GitStream folder
       shell: bash
       run: |


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1B7k5rcQaecoqYkQzjLy3UCNXct17ZOE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Vol20V8)

- add ability  to pass `pull_docker_from_cache` in order to store docker in github cache