### PR TITLE
Add option to update Docker cache key based on the number of times th…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: "Run parser in debug mode"
     required: false
     default: false
+  update_times_a_day:
+    description: 'Number of times the docker should be pull from the docker registry. Whole number between 1 and 24'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -100,6 +103,36 @@ runs:
         ref: ${{ fromJSON(fromJSON(github.event.inputs.client_payload)).cmRepoRef }}
         path: "gitstream/cm/"
 
+    - name: Get Docker cache key
+      id: cache-key
+      if: ${{ inputs.update_times_a_day }}
+      uses: actions/github-script@v7
+      env:
+        UPDATE_TIMES_A_DAY: ${{ inputs.update_times_a_day }}
+      with:
+        script: |
+          require('${{ github.action_path }}/script.js')(core);
+
+    - name: Cache Docker
+      id: cache-gitstream-docker
+      if: ${{ env.DOCKER_KEY }}
+      uses: actions/cache@v4
+      with:
+        path: /tmp/**.tar
+        key: ${{ env.DOCKER_KEY }}
+
+    - name: Docker Pull
+      if: steps.cache-gitstream-docker.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        docker pull gitstream/rules-engine:latest
+        docker save -o /tmp/${{ env.DOCKER_KEY }}.tar gitstream/rules-engine:latest
+
+    - name: Docker Load
+      if: steps.cache-gitstream-docker.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load -i /tmp/${{ env.DOCKER_KEY }}.tar
+
     - name: Run The Action
       if: always()
       run: |
@@ -109,7 +142,6 @@ runs:
           value="${!var}"
           echo "$var=$value" >> "$env_file"
         done
-        docker pull gitstream/rules-engine:latest
         docker run --env-file $env_file \
           -v $(pwd)/gitstream:/code \
           -e HEAD_REF=$'upstream/${{ steps.safe-strings.outputs.head_ref }}' \

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: false
   update_times_a_day:
-    description: 'Number of times the docker should be pull from the docker registry. Whole number between 1 and 24'
+    description: 'Number of times a day the docker should be pull from the docker registry. Whole number between 1 and 24'
     required: false
 runs:
   using: "composite"

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 module.exports = core => {
   const { RUNNER_OS, UPDATE_TIMES_A_DAY } = process.env;
 
-  if (UPDATE_TIMES_A_DAY) {
+  if (!UPDATE_TIMES_A_DAY) {
     return;
   }
 

--- a/script.js
+++ b/script.js
@@ -1,0 +1,18 @@
+module.exports = core => {
+  const { RUNNER_OS, UPDATE_TIMES_A_DAY } = process.env;
+  const times = Number(UPDATE_TIMES_A_DAY);
+
+  // calculate the docker-key cache value
+  if (UPDATE_TIMES_A_DAY) {
+    if (!Number.isInteger(times) || times <= 0 || times >= 25) {
+      core.error(`"update_times_a_day" should be a whole number in range [1..24]`);
+      process.exit(2);
+    }
+
+    const date = new Date();
+    const uniqNum = Math.ceil(((date.getHours() + 1) / 24) * times);
+    const uniqValue = `${date.toLocaleDateString('en-US').replaceAll('/', '-')}-${uniqNum}`;
+    const dockerKey = `${RUNNER_OS}-gitstream-docker-${uniqValue}`;
+    core.exportVariable('DOCKER_KEY', dockerKey);
+  }
+};

--- a/script.js
+++ b/script.js
@@ -1,18 +1,21 @@
 module.exports = core => {
   const { RUNNER_OS, UPDATE_TIMES_A_DAY } = process.env;
-  const times = Number(UPDATE_TIMES_A_DAY);
+
+  if (UPDATE_TIMES_A_DAY) {
+    return;
+  }
 
   // calculate the docker-key cache value
-  if (UPDATE_TIMES_A_DAY) {
-    if (!Number.isInteger(times) || times <= 0 || times >= 25) {
-      core.error(`"update_times_a_day" should be a whole number in range [1..24]`);
-      process.exit(2);
-    }
+  const times = Number(UPDATE_TIMES_A_DAY);
 
-    const date = new Date();
-    const uniqNum = Math.ceil(((date.getHours() + 1) / 24) * times);
-    const uniqValue = `${date.toLocaleDateString('en-US').replaceAll('/', '-')}-${uniqNum}`;
-    const dockerKey = `${RUNNER_OS}-gitstream-docker-${uniqValue}`;
-    core.exportVariable('DOCKER_KEY', dockerKey);
+  if (!Number.isInteger(times) || times <= 0 || times >= 25) {
+    core.error(`"update_times_a_day" should be a whole number in range [1..24]`);
+    process.exit(2);
   }
+
+  const date = new Date();
+  const uniqNum = Math.ceil(((date.getHours() + 1) / 24) * times);
+  const uniqValue = `${date.toLocaleDateString('en-US').replaceAll('/', '-')}-${uniqNum}`;
+  const dockerKey = `${RUNNER_OS}-gitstream-docker-${uniqValue}`;
+  core.exportVariable('DOCKER_KEY', dockerKey);
 };


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1zsoTCBL750Sfn8lAqgFGgDhhEolmpj88%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=yqbLwIZ)

```yaml
usage:
uses: linear-b/gitstream-github-action@v1-cache
with:
    update_times_a_day: 6
```
update_times_a_day = [1..24] it's mean
1 - will pull image from registry 1 time a day
4 - will pull image from registry 4 times a day
24 - will  pull image from registry 24 times a day
etc...


| Screenshot | Screenshot |
|---|---|
|in case of wrong value, will be a relevant message|![image](https://github.com/linear-b/gitstream-github-action/assets/289035/43d1bb43-9352-440c-a1c1-688592d73392)|
