### PR TITLE
Fix escaping in ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ out
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+
+# yalc
+.yalc
+.yalc.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@linearb/gitstream-core": "1.3.140"
+        "@linearb/gitstream-core": "1.3.145"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -1421,9 +1421,9 @@
       }
     },
     "node_modules/@linearb/gitstream-core": {
-      "version": "1.3.140",
-      "resolved": "https://linearb.jfrog.io/linearb/api/npm/npm-local/@linearb/gitstream-core/-/@linearb/gitstream-core-1.3.140.tgz",
-      "integrity": "sha512-PfZTPbBDeq0ETj/P/+NX6La04QNPlwk2zcwgoX5MKNq/IutlSBpEGS5rtcfBKp1ijO25UXshyIbm28CFR7CS5w==",
+      "version": "1.3.145",
+      "resolved": "https://linearb.jfrog.io/linearb/api/npm/npm-local/@linearb/gitstream-core/-/@linearb/gitstream-core-1.3.145.tgz",
+      "integrity": "sha512-v9AbQQ1TMQyrdWIXSzW2M4cJMYh+Yarkpysmref4htIUdS6Z5xDeTv0Kcb0AIIEZrEjpL9M+JQUBtKKdrh4Riw==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@amplitude/node": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@linearb/gitstream-core": "1.3.140"
+    "@linearb/gitstream-core": "1.3.145"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1X31ikNoNValB4aGK9lWLnAJ8vRtiJrJ8%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=8tpHZ7r)

fix escaping in `ignore_files`