### PR TITLE
LINBEE-7812 chore: update logs @linearb/gitstream-core to version 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@linearb/gitstream-core": "2.0.1"
+        "@linearb/gitstream-core": "2.0.2"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -1488,9 +1488,9 @@
       }
     },
     "node_modules/@linearb/gitstream-core": {
-      "version": "2.0.1",
-      "resolved": "https://linearb.jfrog.io/linearb/api/npm/npm-local/@linearb/gitstream-core/-/@linearb/gitstream-core-2.0.1.tgz",
-      "integrity": "sha512-O8uV+uR0d+IqHhX/R5CNNt3f2Gs6DulxeC71XYjBSDe4VLRO71peQ+KDGbYyc66DtFNjLsUaa+3xXWFG0voZdQ==",
+      "version": "2.0.2",
+      "resolved": "https://linearb.jfrog.io/linearb/api/npm/npm-local/@linearb/gitstream-core/-/@linearb/gitstream-core-2.0.2.tgz",
+      "integrity": "sha512-GOU62BU6EcnPiShchS+88lNoRlbIfdyngHXUH2MwisNKHRaxYYnNT4/yWKYMlz81TVXE0Gh4XbMDuPaCBsTSjQ==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@amplitude/node": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@linearb/gitstream-core": "2.0.1"
+    "@linearb/gitstream-core": "2.0.2"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19Yo0rE63yCvTS31gMJv1QMLQlNhJYjSg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=-asPRmy)

update internal logs