### PR TITLE
LINBEE-9077 - add the ability to skip clone + download artifact

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -150,3 +150,11 @@ runs:
         IS_ENABLE_CACHE: ${{ env.IS_ENABLE_CACHE || 'false' }}
         RUN_DATA_CACHE: ${{ env.RUN_DATA_CACHE}}
         IS_ENABLE_DEBUG_ARTIFACTS: ${{ env.IS_ENABLE_DEBUG_ARTIFACTS || 'false' }}
+
+    - name: Upload artifacts
+      if: ${{ env.IS_ENABLE_DEBUG_ARTIFACTS == 'true' || env.IS_ENABLE_CACHE == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        retention-days: 7
+        name: output
+        path: code/output

--- a/action.yml
+++ b/action.yml
@@ -140,8 +140,6 @@ runs:
       shell: bash
       run: |
         echo "yeela-debug env: ${{ env.MY_ENV_VAR }}"
-        echo "yeela-debug vars: ${{ vars.MY_ENV_VAR }}"
-
 
     - name: Install Dependencies for plugins
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,8 @@ runs:
     - name: yeela test
       shell: bash
       run: |
-        echo "yeela-debug: ${{ env.MY_ENV_VAR }}"
+        echo "yeela-debug env: ${{ env.MY_ENV_VAR }}"
+        echo "yeela-debug vars: ${{ vars.MY_ENV_VAR }}"
 
 
     - name: Install Dependencies for plugins

--- a/action.yml
+++ b/action.yml
@@ -124,6 +124,7 @@ runs:
         name: output
 
     - name: Read artifact content
+      if: ${{ fromJson(inputs.client_payload).shouldUseCache == 'true' && fromJson(inputs.client_payload).isCacheEnable == 'true' }}
       id: read-artifact
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
 
     - name: Checkout cm repo
       uses: actions/checkout@v4
-      if: ${{ (fromJson(inputs.client_payload).shouldUseCache || 'false') == 'false' && (fromJson(inputs.client_payload).isCacheEnable || 'false') == 'false' && fromJson(inputs.client_payload).hasCmRepo == 'true') }}
+      if: ${{ (fromJson(inputs.client_payload).shouldUseCache || 'false') == 'false' && (fromJson(inputs.client_payload).isCacheEnable || 'false') == 'false' && fromJson(inputs.client_payload).hasCmRepo == 'true' }}
       with:
         repository: '${{ fromJSON(fromJSON(inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(inputs.client_payload)).cmRepo }}'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmRepoRef }}

--- a/action.yml
+++ b/action.yml
@@ -132,11 +132,6 @@ runs:
         RUN_DATA_CACHE=$(cat $GITHUB_WORKSPACE/run_data_cache.json | jq -c)
         echo "RUN_DATA_CACHE=$RUN_DATA_CACHE" >> $GITHUB_ENV
 
-    - name: yeela test
-      shell: bash
-      run: |
-        echo "yeela-debug env: ${{ env.MY_ENV_VAR }}"
-
     - name: Install Dependencies for plugins
       shell: bash
       run: npm i --silent moment lodash axios @octokit/rest
@@ -152,6 +147,6 @@ runs:
         RULES_RESOLVER_TOKEN: ${{ inputs.resolver_token }}
         DEBUG_MODE: ${{ inputs.debug_mode }}
         IS_NON_COMMIT_EVENT: ${{ fromJSON(fromJSON(inputs.client_payload)).isNonCommitEvent || 'false' }}
-        IS_ENABLE_CACHE: true
+        IS_ENABLE_CACHE: ${{ env.IS_ENABLE_CACHE || 'false' }}
         RUN_DATA_CACHE: ${{ env.RUN_DATA_CACHE}}
-        IS_ENABLE_DEBUG_ARTIFACTS: true
+        IS_ENABLE_DEBUG_ARTIFACTS: ${{ env.IS_ENABLE_DEBUG_ARTIFACTS || 'false' }}

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,7 @@ runs:
           }
 
     - name: Checkout Pull Request branches history
+      if: ${{ (fromJson(inputs.client_payload).shouldUseCache || 'false') == 'false' && (fromJson(inputs.client_payload).isCacheEnable || 'false') == 'false' }}
       shell: bash
       run: |
         ALL=2147483647
@@ -96,12 +97,13 @@ runs:
         git checkout $'${{ steps.safe-strings.outputs.head_ref }}'
 
     - name: Create cm folder
+      if: ${{ (fromJson(inputs.client_payload).shouldUseCache || 'false') == 'false' && (fromJson(inputs.client_payload).isCacheEnable || 'false') == 'false' }}
       shell: bash
       run: cd gitstream && mkdir cm
 
     - name: Checkout cm repo
       uses: actions/checkout@v4
-      if: ${{ fromJSON(fromJSON(inputs.client_payload)).hasCmRepo == true }}
+      if: ${{ (fromJson(inputs.client_payload).shouldUseCache || 'false') == 'false' && (fromJson(inputs.client_payload).isCacheEnable || 'false') == 'false' && fromJson(inputs.client_payload).hasCmRepo == 'true') }}
       with:
         repository: '${{ fromJSON(fromJSON(inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(inputs.client_payload)).cmRepo }}'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmRepoRef }}
@@ -110,6 +112,24 @@ runs:
     - name: Volume folder
       shell: bash
       run: mv gitstream code
+
+    - name: Download cache artifact
+      id: run-data-artifact
+      uses: actions/download-artifact@v4
+      if: ${{ fromJson(inputs.client_payload).shouldUseCache == 'true' && fromJson(inputs.client_payload).isCacheEnable == 'true' }}
+      with:
+        github-token: ${{ fromJSON(fromJSON(inputs.client_payload)).githubToken || github.token }}
+        repository: ${{ inputs.full_repository }}
+        run-id: ${{ fromJSON(fromJSON(inputs.client_payload)).artifactRunId }}
+        name: output
+
+    - name: Read artifact content
+      id: read-artifact
+      shell: bash
+      run: |
+        cat $GITHUB_WORKSPACE/run_data_cache.json
+        RUN_DATA_CACHE=$(cat $GITHUB_WORKSPACE/run_data_cache.json | jq -c)
+        echo "RUN_DATA_CACHE=$RUN_DATA_CACHE" >> $GITHUB_ENV
 
     - name: Install Dependencies for plugins
       shell: bash
@@ -125,3 +145,6 @@ runs:
         RULES_RESOLVER_URL: ${{ inputs.resolver_url }}
         RULES_RESOLVER_TOKEN: ${{ inputs.resolver_token }}
         DEBUG_MODE: ${{ inputs.debug_mode }}
+        SHOULD_USE_CACHE: ${{ fromJSON(fromJSON(inputs.client_payload)).shouldUseCache || 'false' }}
+        IS_CACHE_ENABLE: ${{ fromJSON(fromJSON(inputs.client_payload)).isCacheEnable || 'false' }}
+        RUN_DATA_CACHE: ${{ env.RUN_DATA_CACHE }}

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: 'Run parser in debug mode'
     required: false
     default: 'false'
-  is_enable_cache:
-    description: 'Enable git cache'
-    required: false
-    default: 'false'
 
 runs:
   using: composite
@@ -156,5 +152,6 @@ runs:
         RULES_RESOLVER_TOKEN: ${{ inputs.resolver_token }}
         DEBUG_MODE: ${{ inputs.debug_mode }}
         IS_NON_COMMIT_EVENT: ${{ fromJSON(fromJSON(inputs.client_payload)).isNonCommitEvent || 'false' }}
-        IS_ENABLE_CACHE: ${{ inputs.is_enable_cache }}
+        IS_ENABLE_CACHE: true
         RUN_DATA_CACHE: ${{ env.RUN_DATA_CACHE}}
+        IS_ENABLE_DEBUG_ARTIFACTS: true

--- a/action.yml
+++ b/action.yml
@@ -155,6 +155,6 @@ runs:
       if: ${{ env.IS_ENABLE_DEBUG_ARTIFACTS == 'true' || env.IS_ENABLE_CACHE == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        retention-days: 7
+        retention-days: 2
         name: output
         path: code/output

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Run parser in debug mode'
     required: false
     default: 'false'
+  is_enable_cache:
+    description: 'Enable git cache'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -132,6 +136,12 @@ runs:
         RUN_DATA_CACHE=$(cat $GITHUB_WORKSPACE/run_data_cache.json | jq -c)
         echo "RUN_DATA_CACHE=$RUN_DATA_CACHE" >> $GITHUB_ENV
 
+    - name: yeela test
+      shell: bash
+      run: |
+        echo "yeela-debug: ${{ env.MY_ENV_VAR }}"
+
+
     - name: Install Dependencies for plugins
       shell: bash
       run: npm i --silent moment lodash axios @octokit/rest
@@ -146,6 +156,6 @@ runs:
         RULES_RESOLVER_URL: ${{ inputs.resolver_url }}
         RULES_RESOLVER_TOKEN: ${{ inputs.resolver_token }}
         DEBUG_MODE: ${{ inputs.debug_mode }}
-        SHOULD_USE_CACHE: ${{ fromJSON(fromJSON(inputs.client_payload)).shouldUseCache || 'false' }}
-        IS_CACHE_ENABLE: ${{ fromJSON(fromJSON(inputs.client_payload)).isCacheEnable || 'false' }}
-        RUN_DATA_CACHE: ${{ env.RUN_DATA_CACHE }}
+        IS_NON_COMMIT_EVENT: ${{ fromJSON(fromJSON(inputs.client_payload)).isNonCommitEvent || 'false' }}
+        IS_ENABLE_CACHE: ${{ inputs.is_enable_cache }}
+        RUN_DATA_CACHE: ${{ env.RUN_DATA_CACHE}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@linearb/gitstream-core": "2.1.33"
+        "@linearb/gitstream-core": "2.1.33-13"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -1423,9 +1423,9 @@
       }
     },
     "node_modules/@linearb/gitstream-core": {
-      "version": "2.1.33",
-      "resolved": "https://linearb.jfrog.io/linearb/api/npm/npm-local/@linearb/gitstream-core/-/@linearb/gitstream-core-2.1.33.tgz",
-      "integrity": "sha512-j4QhyMbrDzYYPcvjTBlxJZ70YvOgWKfELrP66xVneanSuMqkC1WvbVzJXWxvM6wtvJvKrfzg0J1dYSYLopxv8A==",
+      "version": "2.1.33-13",
+      "resolved": "https://linearb.jfrog.io/linearb/api/npm/npm-local/@linearb/gitstream-core/-/@linearb/gitstream-core-2.1.33-13.tgz",
+      "integrity": "sha512-BmvQcIwp8DD0ak/rOlB6v9XpgsapfFJ/fY1vwzHTcssT+BJbLD4DsYPcsgbm3dQG1mVY/wH2bklctsiGCkikBw==",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@gitbeaker/rest": "^40.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@linearb/gitstream-core": "2.1.33"
+    "@linearb/gitstream-core": "2.1.33-13"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1EBeqWBm2fJdszbIFeOzpqy9S2nO57bs%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=PDa03TT)

- Implement the option to bypass cloning based on the `shouldUseCache` and `isCacheEnable` boolean flags
- Inject 3 env variables into `gitstream-core`: `SHOULD_USE_CACHE`, `IS_CACHE_ENABLE`, and `RUN_DATA_CACHE`
- This code won't activate the cache unless we add logic in `gitstream-sls-pipeline` to calculate `shouldUseCache`, `isCacheEnable`, and `artifactRunId`