### PR TITLE
Linbee-9931 codeowners plugin not working

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
 
     - name: Install Dependencies for plugins
       shell: bash
-      run: npm i --silent moment lodash axios @octokit/rest
+      run: npm i --silent moment lodash axios @octokit/rest@20.1.1
 
     - name: Run RulesEngine
       shell: bash


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18ZluA4fPyvDqmIXtKRC6UrapQM2ixLqw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=FAtFKn_)

update the  `@octokit/rest` to `v20` from `latest` ([v21](https://github.com/octokit/rest.js/releases/tag/v21.0.0)) which has breaking changes with ESM