### PR TITLE
LINBEE-14851 - Add checkout step for CM organization in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,15 @@ runs:
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmRepoRef }}
         path: gitstream/cm/
 
+    - name: Checkout cm org
+      uses: actions/checkout@v4
+      if: ${{ fromJSON(fromJSON(inputs.client_payload)).hasCmOrg == true && (env.SKIP_GIT_CLONE == 'false' || env.CACHE_DOWNLOAD_FAILED == 'true')}}
+      with:
+        repository: 'cm/cm'
+        ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmOrgRef }}
+        path: gitstream/cm-org/
+
+
     - name: Volume folder
       shell: bash
       run: mv gitstream code

--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,7 @@ runs:
       with:
         repository: 'cm/cm'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmOrgRef }}
-        path: gitstream/cm-org/
+        path: gitstream/cm/
 
     - name: Volume folder
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,7 @@ runs:
         IS_NON_COMMIT_ARG: ${{ fromJSON(fromJSON(inputs.client_payload)).isNonCommitEvent }}
         ENABLE_CACHE_ARG: ${{ env.ENABLE_CACHE }}
         RUN_ID_ARG: ${{ fromJSON(fromJSON(inputs.client_payload)).artifactRunId }}
+        CACHE_DOWNLOAD_FAILED_ARG: ${{ env.CACHE_DOWNLOAD_FAILED }}
       with:
         script: |
           require('${{ github.action_path }}/scripts/get-condition-vars.js')(core);
@@ -126,7 +127,7 @@ runs:
         script: require('${{ github.action_path }}/scripts/check-cache-download-status')(core);
 
     - name: Checkout Pull Request branches history
-      if: ${{ env.SKIP_GIT_CLONE == 'false' || env.CACHE_DOWNLOAD_FAILED == 'true' }}
+      if: ${{ env.SHOULD_CHECKOUT == 'true' }}
       shell: bash
       run: |
         ALL=2147483647
@@ -139,13 +140,13 @@ runs:
         git checkout $'${{ steps.safe-strings.outputs.head_ref }}'
 
     - name: Create cm folder
-      if: ${{ env.SKIP_GIT_CLONE == 'false' || env.CACHE_DOWNLOAD_FAILED == 'true' }}
+      if: ${{ env.SHOULD_CHECKOUT == 'true' }}
       shell: bash
       run: cd gitstream && mkdir cm
 
     - name: Checkout cm repo
       uses: actions/checkout@v4
-      if: ${{ fromJSON(fromJSON(inputs.client_payload)).hasCmRepo == true && (env.SKIP_GIT_CLONE == 'false' || env.CACHE_DOWNLOAD_FAILED == 'true')}}
+      if: ${{ fromJSON(fromJSON(inputs.client_payload)).hasCmRepo == true && env.SHOULD_CHECKOUT == 'true'}}
       with:
         repository: '${{ fromJSON(fromJSON(inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(inputs.client_payload)).cmRepo }}'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmRepoRef }}
@@ -153,12 +154,11 @@ runs:
 
     - name: Checkout cm org
       uses: actions/checkout@v4
-      if: ${{ fromJSON(fromJSON(inputs.client_payload)).hasCmOrg == true && (env.SKIP_GIT_CLONE == 'false' || env.CACHE_DOWNLOAD_FAILED == 'true')}}
+      if: ${{ fromJSON(fromJSON(inputs.client_payload)).hasCmOrg == true && env.SHOULD_CHECKOUT == 'true'}}
       with:
         repository: 'cm/cm'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmOrgRef }}
         path: gitstream/cm-org/
-
 
     - name: Volume folder
       shell: bash

--- a/scripts/get-condition-vars.js
+++ b/scripts/get-condition-vars.js
@@ -1,7 +1,12 @@
 /* eslint-disable import/no-commonjs */
 
 module.exports = core => {
-  const { IS_NON_COMMIT_ARG, ENABLE_CACHE_ARG, RUN_ID_ARG, CACHE_DOWNLOAD_FAILED } = process.env
+  const {
+    IS_NON_COMMIT_ARG,
+    ENABLE_CACHE_ARG,
+    RUN_ID_ARG,
+    CACHE_DOWNLOAD_FAILED
+  } = process.env
   try {
     const isRunIdExists = !!RUN_ID_ARG
 
@@ -13,9 +18,8 @@ module.exports = core => {
     core.exportVariable('IS_NON_COMMIT_EVENT', IS_NON_COMMIT_ARG)
     core.exportVariable('SKIP_GIT_CLONE', skipGitClone.toString())
 
-    const shouldCheckout = !skipGitClone || CACHE_DOWNLOAD_FAILED === 'true';
-    core.exportVariable('SHOULD_CHECKOUT', shouldCheckout.toString());
-
+    const shouldCheckout = !skipGitClone || CACHE_DOWNLOAD_FAILED === 'true'
+    core.exportVariable('SHOULD_CHECKOUT', shouldCheckout.toString())
   } catch (error) {
     core.warn(`Failed to get condition variables: ${error.message}`)
 

--- a/scripts/get-condition-vars.js
+++ b/scripts/get-condition-vars.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-commonjs */
 
 module.exports = core => {
-  const { IS_NON_COMMIT_ARG, ENABLE_CACHE_ARG, RUN_ID_ARG } = process.env
+  const { IS_NON_COMMIT_ARG, ENABLE_CACHE_ARG, RUN_ID_ARG, CACHE_DOWNLOAD_FAILED } = process.env
   try {
     const isRunIdExists = !!RUN_ID_ARG
 
@@ -12,10 +12,15 @@ module.exports = core => {
 
     core.exportVariable('IS_NON_COMMIT_EVENT', IS_NON_COMMIT_ARG)
     core.exportVariable('SKIP_GIT_CLONE', skipGitClone.toString())
+
+    const shouldCheckout = !skipGitClone || CACHE_DOWNLOAD_FAILED === 'true';
+    core.exportVariable('SHOULD_CHECKOUT', shouldCheckout.toString());
+
   } catch (error) {
     core.warn(`Failed to get condition variables: ${error.message}`)
 
     core.exportVariable('IS_NON_COMMIT_EVENT', 'false')
     core.exportVariable('SKIP_GIT_CLONE', 'false')
+    core.exportVariable('SHOULD_CHECKOUT', 'true')
   }
 }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18Flr8aCRtVhDX9QZjLL2ZzK8wqofSxc%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://moontower.gitstream.cm/v2/badge/collaboration-page?magicLinkId=o9RD28K)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Adds support for organization-level CM repo checkout and improves git clone control through a new SHOULD_CHECKOUT variable.

Main changes:
- Introduces CM org repository checkout functionality with new hasCmOrg condition
- Replaces multiple SKIP_GIT_CLONE conditions with single SHOULD_CHECKOUT variable
- Adds CACHE_DOWNLOAD_FAILED_ARG to condition variables for better cache handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
