### PR TITLE
Add default remote configuration for git checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
         all=2147483647
         cd gitstream
         cd repo
+        git config checkout.defaultRemote origin
         git fetch --deepen=$all origin $'${{ steps.safe-strings.outputs.base_ref }}'
         git remote add upstream $'${{ steps.safe-strings.outputs.url }}'
         git fetch --deepen=$all upstream $'${{ steps.safe-strings.outputs.head_ref }}'


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add default remote configuration to git operations when checking out PR branches.

Main changes:
- Set 'checkout.defaultRemote' to 'origin' for consistent remote reference behavior
- Ensures proper reference handling during git fetch operations
- Prevents potential branch checkout issues with multiple remotes

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
