### PR TITLE
fix: update PR title format for gitstream-core bump [skip ci]

### DIFF
--- a/.github/workflows/bump-gitstream-core.yml
+++ b/.github/workflows/bump-gitstream-core.yml
@@ -71,6 +71,6 @@ jobs:
           git push origin HEAD:${{ env.BRANCH_NAME }}
           gh pr create \
             --base develop \
-            --title "Bump \`@linearb/gitstream-core\` to \`${{ env.VERSION }}\`" \
+            --title "Bump @linearb/gitstream-core to ${{ env.VERSION }}" \
             --body-file pr_description.txt \
             --head ${{ env.BRANCH_NAME }} ${{ env.REVIEWER_ARG }} ${{ env.LABEL_ARG }}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update PR title format for gitstream-core bump workflow by removing backticks from package name and version.
Main changes:
- Removed backtick characters from PR title formatting in GitHub workflow automation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
