### PR TITLE
[skip ci] Update bump-gitstream-core workflow: add backticks to PR title

### DIFF
--- a/.github/workflows/bump-gitstream-core.yml
+++ b/.github/workflows/bump-gitstream-core.yml
@@ -71,6 +71,6 @@ jobs:
           git push origin HEAD:${{ env.BRANCH_NAME }}
           gh pr create \
             --base develop \
-            --title "Bump @linearb/gitstream-core to ${{ env.VERSION }}" \
+            --title "Bump \`@linearb/gitstream-core\` to \`${{ env.VERSION }}\`" \
             --body-file pr_description.txt \
             --head ${{ env.BRANCH_NAME }} ${{ env.REVIEWER_ARG }} ${{ env.LABEL_ARG }}


### PR DESCRIPTION
## Summary

Updates the bump-gitstream-core workflow to improve formatting:

- Add backticks around `@linearb/gitstream-core` and version in PR titles for better readability

## Changes Made

- Updated `.github/workflows/bump-gitstream-core.yml`:
  - Line 74: Added backticks to PR title format

## Notes

- The commit message format was already correct in this repo (no backticks)
- Only the PR title needed updating

🔗 **LINBEE-18911**: https://linearb.atlassian.net/browse/LINBEE-18911
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update bump-gitstream-core workflow to format package name and version with backticks in PR title for better readability.

Main changes:
- Added backticks around package name and version in PR title of the automated bump workflow

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
