### PR TITLE
fix: remove extra backslash escaping in PR title for bump-gitstream-core workflow [skip ci]

### DIFF
--- a/.github/workflows/bump-gitstream-core.yml
+++ b/.github/workflows/bump-gitstream-core.yml
@@ -71,6 +71,6 @@ jobs:
           git push origin HEAD:${{ env.BRANCH_NAME }}
           gh pr create \
             --base develop \
-            --title "Bump \`@linearb/gitstream-core\` to \`${{ env.VERSION }}\`" \
+            --title "Bump `@linearb/gitstream-core` to `${{ env.VERSION }}`" \
             --body-file pr_description.txt \
             --head ${{ env.BRANCH_NAME }} ${{ env.REVIEWER_ARG }} ${{ env.LABEL_ARG }}


### PR DESCRIPTION
Fixes the issue where the bump-gitstream-core workflow was generating PR titles with extra backslashes due to incorrect escaping of backticks.

## Problem
The workflow was generating PR titles with escaped backticks that displayed incorrectly.

## Solution
Removed the backslash escaping of backticks in the --title parameter.

Fixes LINBEE-18911

🤖 Generated with [Claude Code](https://claude.ai/code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix escaped backtick characters in PR title for the gitstream-core bump workflow to prevent malformed title rendering.

Main changes:
- Removed unnecessary backslash escaping from backtick characters in the PR title parameter

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
