### PR TITLE
chore: remove unused action group and add Slack notifications for success and failure in create-tag workflow [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    groups:
-      actions-minor:
-        update-types:
-          - minor
-          - patch
 
   - package-ecosystem: npm
     directory: /

--- a/.github/workflows/create-tag-on-merge.yml
+++ b/.github/workflows/create-tag-on-merge.yml
@@ -10,6 +10,9 @@ on:
       - dist/**
       - package*.json
 
+env:
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WORKFLOWS_DEPLOYMENT_WEBHOOK }}
+
 jobs:
   create-tag:
     runs-on: ubuntu-24.04
@@ -112,3 +115,26 @@ jobs:
           git add package.json package-lock.json dist/
           git commit -m "Update v2-lite to $NEW_TAG"
           git push origin v2-lite
+
+      - name: Success Slack Notification
+        if: steps.should-deploy.outputs.result == 'true' && success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
+          SLACK_TITLE: ${{ github.repository }}
+          SLACK_FOOTER: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run> | <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.NEW_TAG }}|${{ env.NEW_TAG }}>
+          SLACK_MESSAGE: |
+            Released `${{ env.NEW_TAG }}` to `gitstream-github-action`
+            ${{ steps.should-deploy.outputs.release-notes }}
+
+      - name: Failure Slack Notification
+        if: steps.should-deploy.outputs.result == 'true' && failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
+          SLACK_TITLE: ${{ github.repository }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_FOOTER: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run>
+          SLACK_MESSAGE: Failed to release `${{ env.NEW_TAG }}` to `gitstream-github-action`


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update GitHub workflows by removing unused Dependabot action group and adding Slack notifications for release status in the create-tag workflow.

Main changes:
- Removed unused "actions-minor" group from Dependabot configuration
- Added environment variable for Slack webhook integration in create-tag workflow
- Implemented success and failure Slack notifications for release deployments

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
