### PR TITLE
fix: path in trigger for create-tag-on-merge workflow [skip ci]

### DIFF
--- a/.github/workflows/create-tag-on-merge.yml
+++ b/.github/workflows/create-tag-on-merge.yml
@@ -8,7 +8,9 @@ on:
     paths:
       - src/**
       - dist/**
+      - scripts/**
       - package*.json
+      - action.yml
 
 env:
   SLACK_WEBHOOK: ${{ secrets.SLACK_WORKFLOWS_DEPLOYMENT_WEBHOOK }}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix deployment workflow trigger by updating path patterns in create-tag-on-merge GitHub workflow.
Main changes:
- Added scripts/** directory to workflow trigger paths
- Added action.yml file to workflow trigger paths

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
