### PR TITLE
LINBEE-20702: Optimize cm repo clone with shallow depth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,6 +147,7 @@ runs:
         repository: '${{ fromJSON(fromJSON(inputs.client_payload)).owner }}/${{ fromJSON(fromJSON(inputs.client_payload)).cmRepo }}'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmRepoRef }}
         path: gitstream/cm/
+        fetch-depth: 1
 
     - name: Checkout cm org
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -155,6 +156,7 @@ runs:
         repository: 'cm/cm'
         ref: ${{ fromJSON(fromJSON(inputs.client_payload)).cmOrgRef }}
         path: gitstream/cm/
+        fetch-depth: 1
 
     - name: Volume folder
       shell: bash


### PR DESCRIPTION
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimize Git repository cloning operations by implementing shallow cloning for CM repositories to improve workflow performance.
Main changes:
- Added fetch-depth: 1 parameter to CM repo checkout to implement shallow cloning
- Added fetch-depth: 1 parameter to CM org checkout to reduce git data transfer

__CHANGELOG__

**🔧 Improvements**
- Faster clone time for cm repo/org by fetching only the latest commit.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
