### PR TITLE
refactor: use shared slack-notification action [skip ci]

### DIFF
--- a/.github/workflows/create-tag-on-merge.yml
+++ b/.github/workflows/create-tag-on-merge.yml
@@ -118,25 +118,13 @@ jobs:
           git commit -m "Update v2-lite to $NEW_TAG"
           git push origin v2-lite
 
-      - name: Success Slack Notification
-        if: steps.should-deploy.outputs.result == 'true' && success()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          MSG_MINIMAL: true
-          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
-          SLACK_TITLE: ${{ github.repository }}
-          SLACK_FOOTER: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run> | <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.NEW_TAG }}|${{ env.NEW_TAG }}>
-          SLACK_MESSAGE: |
-            Released `${{ env.NEW_TAG }}` to `gitstream-github-action`
-            ${{ steps.should-deploy.outputs.release-notes }}
-
-      - name: Failure Slack Notification
-        if: steps.should-deploy.outputs.result == 'true' && failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          MSG_MINIMAL: true
-          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
-          SLACK_TITLE: ${{ github.repository }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_FOOTER: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run>
-          SLACK_MESSAGE: Failed to release `${{ env.NEW_TAG }}` to `gitstream-github-action`
+      - name: Slack Notification
+        if: steps.should-deploy.outputs.result == 'true' && always()
+        uses: linear-b/shared-workflows/.github/actions/slack-notification@develop
+        with:
+          status: ${{ job.status }}
+          webhook_url: ${{ env.SLACK_WEBHOOK }}
+          footer_links: <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.NEW_TAG }}|${{ env.NEW_TAG }}>
+          message: |
+            ${{ job.status == 'success' && 'Released' || 'Failed to release' }} `${{ env.NEW_TAG }}` to `gitstream-github-action`
+            ${{ job.status == 'success' && steps.should-deploy.outputs.release-notes || '' }}


### PR DESCRIPTION
## Summary
Use the `slack-notification` composite action from shared-workflows.

**JIRA:** https://linearb.atlassian.net/browse/LINBEE-20794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace external Slack notification action with internal shared workflow to standardize notification format and consolidate implementation.
Main changes:
- Replaced rtCamp/action-slack-notify with linear-b/shared-workflows/.github/actions/slack-notification
- Consolidated success and failure notifications into a single conditional action
- Simplified message format while preserving release information and links

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
