### PR TITLE
LINBEE-21919 - continue workflow even if branch was deleted

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,10 +86,10 @@ runs:
         git config checkout.defaultRemote origin
         git fetch --shallow-since="6 months ago" origin $'${{ steps.safe-strings.outputs.base_ref }}'
         git remote add upstream $'${{ steps.safe-strings.outputs.url }}'
-        git fetch --shallow-since="6 months ago" upstream $'${{ steps.safe-strings.outputs.head_ref }}'
-        git checkout -b $'upstream/${{ steps.safe-strings.outputs.head_ref}}' $'upstream/${{ steps.safe-strings.outputs.head_ref}}'
-        git checkout $'${{ steps.safe-strings.outputs.base_ref }}'
-        git checkout $'${{ steps.safe-strings.outputs.head_ref }}'
+        git fetch --shallow-since="6 months ago" upstream $'${{ steps.safe-strings.outputs.head_ref }}' || echo "::warning::Failed to fetch head branch. The branch may have been deleted."
+        git checkout -b $'upstream/${{ steps.safe-strings.outputs.head_ref}}' $'upstream/${{ steps.safe-strings.outputs.head_ref}}' || true
+        git checkout $'${{ steps.safe-strings.outputs.base_ref }}' || true
+        git checkout $'${{ steps.safe-strings.outputs.head_ref }}' || true
 
     - name: Create cm folder
       shell: bash


### PR DESCRIPTION
- Added warnings for failed fetch of the head branch if it has been deleted and  ensure the action continues even if a checkout fails.
<img width="1099" height="687" alt="Screenshot 2026-01-20 at 10 55 54" src="https://github.com/user-attachments/assets/562a2391-19b0-41f6-be98-b58a099839e2" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix workflow to continue execution when head branch has been deleted by adding error handling to git operations.
Main changes:
- Added `|| echo "::warning::..."` to git fetch command to log warning and continue if upstream head branch fetch fails
- Changed git checkout commands to use `|| true` to allow workflow continuation even if branch checkout fails
- Modified git branch creation to handle deletion scenarios gracefully without blocking subsequent steps

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
