### PR TITLE
Pin npm plugin dependency versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
     - name: Install Dependencies for plugins
       shell: bash
       continue-on-error: true
-      run: npm i --silent moment lodash axios @octokit/rest@20.1.1
+      run: npm i --silent moment@2.30.1 lodash@4.18.1 axios@1.14.0 @octokit/rest@20.1.1
 
     - name: Run RulesEngine
       shell: bash


### PR DESCRIPTION
## Summary
- Pin `moment@2.30.1`, `lodash@4.18.1`, and `axios@1.14.0` in the action's plugin dependency install step
- Prevents unexpected breakage from unpinned packages resolving to new major/minor versions

## Test plan
- [ ] Verify gitStream action runs successfully with pinned versions
- [ ] Confirm plugin dependencies install without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Pin npm plugin dependency versions to specific releases to ensure reproducible builds and prevent breaking changes from automatic updates.

Main changes:
- Locked moment dependency to version 2.30.1, lodash to 4.18.1, and axios to 1.14.0
- Maintained existing @octokit/rest version pin at 20.1.1 for consistency
- Changed from floating version resolution to explicit version pinning for build stability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
