### PR TITLE
security: harden npm install against supply chain attacks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -117,10 +117,14 @@ runs:
       shell: bash
       run: mv gitstream code
 
+    - name: Clear npm cache
+      shell: bash
+      run: npm cache clean --force
+
     - name: Install Dependencies for plugins
       shell: bash
       continue-on-error: true
-      run: npm i --silent moment@2.30.1 lodash@4.18.1 axios@1.14.0 @octokit/rest@20.1.1
+      run: npm i --ignore-scripts moment@2.30.1 lodash@4.18.1 axios@1.14.0 @octokit/rest@20.1.1
 
     - name: Run RulesEngine
       shell: bash


### PR DESCRIPTION
## Summary
- Add `npm cache clean --force` before install to prevent stale/malicious cached tarballs
- Add `--ignore-scripts` to block malicious postinstall hooks (e.g. axios supply chain CVE)
- Remove `--silent` to make installed package versions visible in logs

## Context
In response to the axios npm supply chain compromise (March 31, 2026), where attackers published backdoored versions `1.14.1` and `0.30.4` via a hijacked maintainer account. The malicious versions used a `postinstall` hook to deploy a cross-platform RAT. `--ignore-scripts` ensures postinstall hooks are never executed regardless of what version is installed.

## Test plan
- [ ] Trigger a gitStream workflow run and verify `npm cache clean --force` appears in logs
- [ ] Verify `added N packages` output is visible (no --silent)
- [ ] Verify no postinstall scripts are executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Harden npm package installation process to prevent supply chain attacks by disabling script execution and clearing cached packages.

Main changes:
- Added npm cache clean step before dependency installation to prevent poisoned cache exploitation
- Replaced --silent flag with --ignore-scripts to block malicious postinstall scripts from executing
- Reordered workflow to clear cache immediately before installing pinned dependency versions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
