### PR TITLE
fix(ci): pin Node via setup-node in bump-gitstream-core workflow [skip ci]

### DIFF
--- a/.github/workflows/bump-gitstream-core.yml
+++ b/.github/workflows/bump-gitstream-core.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           token: ${{ secrets.CI_USER_GIT_TOKEN }}
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
       - name: Set version to ENV
         run: |
           echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Pin Node.js version in bump-gitstream-core workflow using setup-node action to ensure consistent build environment.

Main changes:
- Added setup-node action with node-version-file pointing to .nvmrc for reproducible Node version management

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
